### PR TITLE
Check for 'None' value of LV size key

### DIFF
--- a/tasks/vg.yaml
+++ b/tasks/vg.yaml
@@ -52,7 +52,8 @@
     lvm_extend_vg_exists is defined and
     lvm_extend_vg_exists.rc > 0 and
     lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and
-    'size' in item
+    'size' in item and
+    item.size != None
   loop: "{{ lvm_extend_vg.value.vols }}"
 
 - name: Create LVM logical volumes without size to fill the rest of the space ({{ lvm_extend_vg.key }})
@@ -66,7 +67,8 @@
     lvm_extend_vg_exists is defined and
     lvm_extend_vg_exists.rc > 0 and
     lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and
-    'size' not in item
+    ('size' not in item or
+    item.size == None)
   loop: "{{ lvm_extend_vg.value.vols }}"
 
 - name: Extend LVM logical volumes with specified size ({{ lvm_extend_vg.key }})
@@ -80,7 +82,8 @@
     lvm_extend_vg_exists is defined and
     lvm_extend_vg_exists.rc == 0 and
     lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and
-    'size' in item
+    'size' in item and
+    item.size != None
   loop: "{{ lvm_extend_vg.value.vols }}"
 
 - name: Extend LVM logical volume without size to fill the rest of the space ({{ lvm_extend_vg.key }})
@@ -93,7 +96,8 @@
     lvm_extend_vg_exists is defined and
     lvm_extend_vg_exists.rc == 0 and
     lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and
-    'size' not in item
+    ('size' not in item or
+    item.size == None)
   loop: "{{ lvm_extend_vg.value.vols }}"
 
 - name: Create or resize filesystem - swap type ({{ lvm_extend_vg.key }})

--- a/tasks/vg.yaml
+++ b/tasks/vg.yaml
@@ -66,9 +66,10 @@
     lvm_extend_disks.stdout_lines | length > 0 and
     lvm_extend_vg_exists is defined and
     lvm_extend_vg_exists.rc > 0 and
-    lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and
-    ('size' not in item or
-    item.size == None)
+    lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and (
+      'size' not in item or
+      item.size == None
+    )
   loop: "{{ lvm_extend_vg.value.vols }}"
 
 - name: Extend LVM logical volumes with specified size ({{ lvm_extend_vg.key }})
@@ -95,9 +96,10 @@
     lvm_extend_disks.stdout_lines | length > 0 and
     lvm_extend_vg_exists is defined and
     lvm_extend_vg_exists.rc == 0 and
-    lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and
-    ('size' not in item or
-    item.size == None)
+    lvm_extend_vg.value.disks | intersect(lvm_extend_disks.stdout_lines) | length > 0 and (
+      'size' not in item or
+      item.size == None
+    )
   loop: "{{ lvm_extend_vg.value.vols }}"
 
 - name: Create or resize filesystem - swap type ({{ lvm_extend_vg.key }})


### PR DESCRIPTION
This allows conditionally setting the LV to fill the disk, by setting the key's value to `None` in a jinja2 condition